### PR TITLE
Removing wait times within process for polling queues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,8 @@ NodeJS Dependencies:
 
 .. image:: https://david-dm.org/CuriBio/mantarray-desktop-app/status.svg
    :target: https://david-dm.org/CuriBio/mantarray-desktop-app
-   :alt: NodeDevDependency Status
+   :alt: NodeDependency Status
 
 .. image:: https://david-dm.org/CuriBio/mantarray-desktop-app/dev-status.svg
    :target: https://david-dm.org/CuriBio/mantarray-desktop-app?type=dev
-   :alt: NodeDependency Status
+   :alt: NodeDevDependency Status

--- a/src/mantarray_desktop_app/file_writer.py
+++ b/src/mantarray_desktop_app/file_writer.py
@@ -53,7 +53,6 @@ from .constants import FILE_WRITER_PERFOMANCE_LOGGING_NUM_CYCLES
 from .constants import MICROSECONDS_PER_CENTIMILLISECOND
 from .constants import REFERENCE_SENSOR_SAMPLING_PERIOD
 from .constants import ROUND_ROBIN_PERIOD
-from .constants import SECONDS_TO_WAIT_WHEN_POLLING_QUEUES
 from .exceptions import InvalidDataTypeFromOkCommError
 from .exceptions import UnrecognizedCommandFromMainToFileWriterError
 
@@ -627,7 +626,7 @@ class FileWriterProcess(InfiniteProcess):
         """
         input_queue = self._board_queues[0][0]
         try:
-            data_packet = input_queue.get(timeout=SECONDS_TO_WAIT_WHEN_POLLING_QUEUES)
+            data_packet = input_queue.get_nowait()
         except queue.Empty:
             return
 

--- a/src/mantarray_desktop_app/file_writer.py
+++ b/src/mantarray_desktop_app/file_writer.py
@@ -486,7 +486,7 @@ class FileWriterProcess(InfiniteProcess):
     def _process_next_command_from_main(self) -> None:
         input_queue = self._from_main_queue
         try:
-            communication = input_queue.get(timeout=SECONDS_TO_WAIT_WHEN_POLLING_QUEUES)
+            communication = input_queue.get_nowait()
         except queue.Empty:
             return
 

--- a/tests/test_file_writer.py
+++ b/tests/test_file_writer.py
@@ -1535,6 +1535,9 @@ def test_FileWriterProcess__ignores_commands_from_main_while_finalizing_files_af
         }
         board_queues[0][0].put(final_ref_data_packet)
     confirm_queue_is_eventually_of_size(board_queues[0][0], 30)
+    time.sleep(
+        QUEUE_CHECK_TIMEOUT_SECONDS
+    )  # Eli (2/1/21): Even though the queue size has been confirmed in the above line, this extra sleep appears necessary to ensure that the subprocess can pull from the queue consistently using `get_nowait`. Not sure why this is required.
     invoke_process_run_and_check_errors(fw_process, num_iterations=30)
     confirm_queue_is_eventually_empty(board_queues[0][0])
     # check command is still ignored

--- a/tests/test_file_writer.py
+++ b/tests/test_file_writer.py
@@ -1194,9 +1194,6 @@ def test_FileWriterProcess__deletes_recorded_well_data_after_stop_time(
         ok_board_queues[0][0],
         expected_remaining_packets_recorded + dummy_packets,
     )
-    # time.sleep(
-    #     QUEUE_CHECK_TIMEOUT_SECONDS
-    # )  # Eli (2/1/21): Even though the queue size has been confirmed in the above line, this extra sleep appears necessary to ensure that the subprocess can pull from the queue consistently using `get_nowait`. Not sure why this is required.
     invoke_process_run_and_check_errors(
         file_writer_process,
         num_iterations=(expected_remaining_packets_recorded + dummy_packets),

--- a/tests/test_file_writer.py
+++ b/tests/test_file_writer.py
@@ -138,6 +138,9 @@ def test_FileWriterProcess_soft_stop_not_allowed_if_incoming_data_still_in_queue
     )
 
     confirm_queue_is_eventually_of_size(board_queues[0][0], 2)
+    time.sleep(
+        QUEUE_CHECK_TIMEOUT_SECONDS
+    )  # Eli (2/1/21): Even though the queue size has been confirmed in the above line, this extra sleep appears necessary to ensure that the subprocess can pull from the queue consistently using `get_nowait`. Not sure why this is required.
 
     file_writer_process.soft_stop()
     invoke_process_run_and_check_errors(file_writer_process)
@@ -989,14 +992,10 @@ def test_FileWriterProcess__begins_building_data_buffer_when_managed_acquisition
     expected_num_items = 3
     for _ in range(expected_num_items):
         board_queues[0][0].put(SIMPLE_CONSTRUCT_DATA_FROM_WELL_0)
-    assert (
-        is_queue_eventually_of_size(
-            board_queues[0][0],
-            expected_num_items,
-            timeout_seconds=QUEUE_CHECK_TIMEOUT_SECONDS,
-        )
-        is True
-    )
+    confirm_queue_is_eventually_of_size(board_queues[0][0], expected_num_items)
+    time.sleep(
+        QUEUE_CHECK_TIMEOUT_SECONDS
+    )  # Eli (2/1/21): Even though the queue size has been confirmed in the above line, this extra sleep appears necessary to ensure that the subprocess can pull from the queue consistently using `get_nowait`. Not sure why this is required.
 
     invoke_process_run_and_check_errors(
         file_writer_process, num_iterations=expected_num_items
@@ -1031,12 +1030,10 @@ def test_FileWriterProcess__removes_packets_from_data_buffer_that_are_older_than
 
     board_queues[0][0].put(old_packet)
     board_queues[0][0].put(new_packet)
-    assert (
-        is_queue_eventually_of_size(
-            board_queues[0][0], 2, timeout_seconds=QUEUE_CHECK_TIMEOUT_SECONDS
-        )
-        is True
-    )
+    confirm_queue_is_eventually_of_size(board_queues[0][0], 2)
+    time.sleep(
+        QUEUE_CHECK_TIMEOUT_SECONDS
+    )  # Eli (2/1/21): Even though the queue size has been confirmed in the above line, this extra sleep appears necessary to ensure that the subprocess can pull from the queue consistently using `get_nowait`. Not sure why this is required.
 
     invoke_process_run_and_check_errors(file_writer_process, num_iterations=2)
 
@@ -1436,6 +1433,10 @@ def test_FileWriterProcess_hard_stop__closes_all_files_after_stop_recording_befo
         }
         board_queues[0][0].put(ref_data_packet)
     confirm_queue_is_eventually_of_size(board_queues[0][0], 30)
+    time.sleep(
+        QUEUE_CHECK_TIMEOUT_SECONDS
+    )  # Eli (2/1/21): Even though the queue size has been confirmed in the above line, this extra sleep appears necessary to ensure that the subprocess can pull from the queue consistently using `get_nowait`. Not sure why this is required.
+
     invoke_process_run_and_check_errors(fw_process, num_iterations=30)
     confirm_queue_is_eventually_empty(board_queues[0][0])
 
@@ -1491,6 +1492,10 @@ def test_FileWriterProcess__ignores_commands_from_main_while_finalizing_files_af
         }
         board_queues[0][0].put(ref_data_packet)
     confirm_queue_is_eventually_of_size(board_queues[0][0], 30)
+    time.sleep(
+        QUEUE_CHECK_TIMEOUT_SECONDS
+    )  # Eli (2/1/21): Even though the queue size has been confirmed in the above line, this extra sleep appears necessary to ensure that the subprocess can pull from the queue consistently using `get_nowait`. Not sure why this is required.
+
     invoke_process_run_and_check_errors(fw_process, num_iterations=30)
     confirm_queue_is_eventually_empty(board_queues[0][0])
 


### PR DESCRIPTION
Having these wait times seems detrimental to the overall ability to measure performance of the subprocesses...everything is reporting 100% because the polling time is longer than the generic "sleep before iterating again" time.  I think with the updates we've made to the multiprocessing testing framework, we should be able to make the tests themselves be more robust to avoid needing to have these internal wait times.

I got things out of FileWriter, but wanted to get this merged before attempting the others.