### PR TITLE
Smoother release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "MantarrayController",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Desktop application for controlling the Mantarray instrument.",
   "author": {
     "name": "Curi Bio",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -154,7 +154,9 @@ app.on("will-quit", function () {
   console.log("will-quit event being handled"); // allow-log
   // mainWindow = null;
 
-  axios.get(`http://localhost:${flask_port}/shutdown`);
+  axios.get(
+    `http://localhost:${flask_port}/shutdown?called_through_app_will_quit=true`
+  );
 });
 
 // win_handler = require("./mainWindow");

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -10,7 +10,35 @@ const yaml = require("js-yaml");
  * @return {string} the semantic version
  */
 const get_current_app_version = function () {
-  return "0.4.2";
+  try {
+    const { electron_app } = require("electron").remote;
+    console.log(
+      "the version from remote module: " + electron_app.app.getVersion()
+    );
+    return "0.4.2";
+  } catch (err) {
+    if (err instanceof TypeError) {
+      // Electron is not actually running, so get the version from package.json
+      console.log("Attempting to read the version from package.json"); // allow-log
+      const path_to_package_json = path.join(
+        __dirname,
+        "..",
+        "..",
+        "package.json"
+      );
+      const package_info = require(path_to_package_json);
+      return package_info.version;
+    } else {
+      console.log(
+        // allow-log
+        "Something other than TypeError detected when trying to require electron.remote: " +
+          err
+      );
+      throw err;
+    }
+  }
+  // return electron_app.getVersion();
+
   // Eli (1/15/21) - can't figure out how to get it working dynamically
   // try {
   //   const {electron_app} = require("electron").remote;

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -10,54 +10,7 @@ const yaml = require("js-yaml");
  * @return {string} the semantic version
  */
 const get_current_app_version = function () {
-  try {
-    const { electron_app } = require("electron").remote;
-    console.log(
-      "the version from remote module: " + electron_app.app.getVersion()
-    );
-    return "0.4.2";
-  } catch (err) {
-    if (err instanceof TypeError) {
-      // Electron is not actually running, so get the version from package.json
-      console.log("Attempting to read the version from package.json"); // allow-log
-      const path_to_package_json = path.join(
-        __dirname,
-        "..",
-        "..",
-        "package.json"
-      );
-      const package_info = require(path_to_package_json);
-      return package_info.version;
-    } else {
-      console.log(
-        // allow-log
-        "Something other than TypeError detected when trying to require electron.remote: " +
-          err
-      );
-      throw err;
-    }
-  }
-  // return electron_app.getVersion();
-
-  // Eli (1/15/21) - can't figure out how to get it working dynamically
-  // try {
-  //   const {electron_app} = require("electron").remote;
-  // }
-  // catch (err) {
-  //   if(err instanceof TypeError){
-  //       // Electron is not actually running, so get the version from package.json
-  //       console.log('Attempting to read the version from package.json') // allow-log
-  //       const path_to_package_json=path.join(__dirname,'..','..','package.json')
-  //       const package_info=require(path_to_package_json)
-  //       return package_info.version
-  //   }
-  //   else {
-  //     console.log( // allow-log
-  //       'Something other than TypeError detected when trying to require electron.remote: ' + err)
-  //     throw err
-  //   }
-  // }
-  // return electron_app.getVersion()
+  return process.env.npm_package_version;
 };
 
 /**

--- a/tests/e2e/sample.spec.js
+++ b/tests/e2e/sample.spec.js
@@ -30,6 +30,8 @@ chromeDriver -v
 const axios = require("axios");
 import sinon from "sinon";
 const child_process = require("child_process");
+const resemble = require("resemblejs");
+
 const ci = require("ci-info");
 const path = require("path");
 const Application = require("spectron").Application;
@@ -43,6 +45,12 @@ const base_screenshot_path = path.join(
   is_windows ? "windows" : "linux",
   "continuous-waveform"
 );
+const box_surrounding_version_number = {
+  left: 229,
+  top: 910,
+  right: 229 + 40,
+  bottom: 910 + 12,
+};
 
 // const { test_with_Spectron } = require('vue-cli-plugin-electron-builder') // may only work with Vue 3 https://nklayman.github.io/vue-cli-plugin-electron-builder/guide/testingAndDebugging.html#testing
 
@@ -389,9 +397,11 @@ describe("window_opening", () => {
 
     const screenshot_path = path.join(this_base_screenshot_path, "init");
     await wait_for_local_server_to_reach_calibration_needed();
+    resemble.outputSettings({ ignoredBox: box_surrounding_version_number });
     await expect(
       spectron_page_visual_regression(app.browserWindow, screenshot_path)
     ).resolves.toBe(true);
+    resemble.outputSettings({ ignoredBox: undefined });
   }, 90000);
   test("When Calibrate is clicked (and waiting some time for calibration to finish), Then the screen shows the Calibrated state", async () => {
     const app = sandbox.the_app;
@@ -406,8 +416,10 @@ describe("window_opening", () => {
 
     const screenshot_path = path.join(this_base_screenshot_path, "calibrated");
 
+    resemble.outputSettings({ ignoredBox: box_surrounding_version_number });
     await expect(
       spectron_page_visual_regression(app.browserWindow, screenshot_path)
     ).resolves.toBe(true);
+    resemble.outputSettings({ ignoredBox: undefined });
   }, 90000);
 });

--- a/tests/e2e/sample.spec.js
+++ b/tests/e2e/sample.spec.js
@@ -46,9 +46,9 @@ const base_screenshot_path = path.join(
   "continuous-waveform"
 );
 const box_surrounding_version_number = {
-  left: 229,
+  left: 237, // Eli (3/29/21): This VRT does still include the major version so that basics of text style and ability to extract the version number can be validated. This seems like a reasonable compromise between testing to make sure nothing is wrong, and not having a brittle test that needs to be updated everytime a minor or patch version bump happens.
   top: 910,
-  right: 229 + 40,
+  right: 237 + 32,
   bottom: 910 + 12,
 };
 

--- a/tests/unit-jest/utils.spec.js
+++ b/tests/unit-jest/utils.spec.js
@@ -63,20 +63,19 @@ describe("utils.js", () => {
           );
         });
         test("When the function is invoked, Then the expected-software-version argument is set to the value returned by get_current_app_version", () => {
+          const spied_get_current_app_version = jest.spyOn(
+            main_utils,
+            "get_current_app_version"
+          );
+
           const actual_args = main_utils.generate_flask_command_line_args(
             store
           );
 
-          // const spied_get_current_app_version = jest.spyOn(
-          //   main_utils,
-          //   "get_current_app_version"
-          // );
           expect(actual_args).toStrictEqual(
             expect.arrayContaining([
               "--expected-software-version=" +
-                // Eli (1/15/21) can't figure out how to get the spy set up correctly
-                // spied_get_current_app_version.mock.results[0].value,
-                "0.4.2",
+                spied_get_current_app_version.mock.results[0].value,
             ])
           );
         });
@@ -132,7 +131,7 @@ describe("utils.js", () => {
     });
 
     describe("get_current_app_version", () => {
-      test("Given that Electron is not actually running (because this is just a unit test), When the function is called, Then it returns the current version of Electron", () => {
+      test("Given that Electron is not actually running (because this is just a unit test), When the function is called, Then it returns the current version of the App", () => {
         const path_to_package_json = path.join(
           __dirname,
           "..",


### PR DESCRIPTION
* got the VRT to ignore the minor and patch version numbers (still included the major version number to have some test that the font/color is correct and that the number is being created...and not some error code)
* Got the unit tests to dynamically extract the app version instead of having it hardcoded--so it doesn't have to be adjusted in the tests when the version changes
* Added a debugging param to the `/shutdown` call from the frontend when its called by the user closing the application