### PR TITLE
Electron version detection fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,6 @@
 Changelog for Mantarray Desktop App
 ===================================
-
-
-0.4.3 (2021-03-29)
+0.4.3 (2021-03-30)
 ------------------
 
 - Added logging for frontend user interface

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -12,13 +12,10 @@ const yaml = require("js-yaml");
 const get_current_app_version = function () {
   // Eli (3/30/21): Do NOT use `process.env.npm_package_version` to try and do this. It works in CI using the test runner, but does not actually work when running on a standalone machine--it just evaluates to undefined.
   // adapted from https://github.com/electron/electron/issues/7085
-  let { current_version } = "";
   if (process.env.NODE_ENV !== "production") {
-    current_version = require("../../package.json").version;
-  } else {
-    current_version = require("electron").app.getVersion();
+    return require("../../package.json").version;
   }
-  return current_version;
+  return require("electron").app.getVersion();
 };
 
 /**

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -10,7 +10,17 @@ const yaml = require("js-yaml");
  * @return {string} the semantic version
  */
 const get_current_app_version = function () {
-  return process.env.npm_package_version;
+  // Eli (3/30/21): Do NOT use `process.env.npm_package_version` to try and do this. It works in CI using the test runner, but does not actually work when running on a standalone machine--it just evaluates to undefined.
+  // adapted from https://github.com/electron/electron/issues/7085
+  let { current_version } = "";
+  if (process.env.NODE_ENV !== "production") {
+    console.log("attempting to obtain app version from package.json"); // allow-log
+    current_version = require("../../package.json").version;
+  } else {
+    console.log("attempting to obtain app version from app.getVersion"); // allow-log
+    current_version = require("electron").app.getVersion();
+  }
+  return current_version;
 };
 
 /**

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -14,10 +14,8 @@ const get_current_app_version = function () {
   // adapted from https://github.com/electron/electron/issues/7085
   let { current_version } = "";
   if (process.env.NODE_ENV !== "production") {
-    console.log("attempting to obtain app version from package.json"); // allow-log
     current_version = require("../../package.json").version;
   } else {
-    console.log("attempting to obtain app version from app.getVersion"); // allow-log
     current_version = require("electron").app.getVersion();
   }
   return current_version;


### PR DESCRIPTION
`process.env.npm_package_version` should apparently NOT be used. It works in CI using the test runner, but does not actually work when running on a standalone machine--it just evaluates to undefined.